### PR TITLE
Fixed plugin to create the target directory if it doesn't already exist.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.classpath
+.project
+.settings
+target

--- a/src/main/java/com/github/janssk1/maven/plugin/graph/GraphMojo.java
+++ b/src/main/java/com/github/janssk1/maven/plugin/graph/GraphMojo.java
@@ -127,6 +127,7 @@ public class GraphMojo
         GraphSerializer graphSerializer = new GraphMLGenerator();
         try {
             File file = new File(outputDirectory, this.artifactId + "-" + this.version + "-" + options.getGraphType() + (options.isIncludeAllTransitiveDependencies() ? "-TRANSITIVE":"") + "-deps.graphml");
+            file.getParentFile().mkdirs();
             graphSerializer.serialize(graph, new FileWriter(file), new RenderOptions().setVertexRenderer(new SizeVertexRenderer()));
             getLog().info("Created dependency graph in " + file);
         } catch (IOException e) {


### PR DESCRIPTION
The plugin currently fails if the target directory doesn't exist.  This patch will make sure that the target directory exists before trying to write the graphml files.  